### PR TITLE
Autonumbering for images and figures

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.abspath('.'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.intersphinx', 'sphinx.ext.numfig'
+    'sphinx.ext.intersphinx'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/conf.py
+++ b/source/conf.py
@@ -345,6 +345,4 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
 
-# numfig:
-numfig_number_figures = True
-numfig_figure_caption_prefix = "Figure"
+numfig = True

--- a/source/conf.py
+++ b/source/conf.py
@@ -346,3 +346,4 @@ texinfo_documents = [
 intersphinx_mapping = {'https://docs.python.org/': None}
 
 numfig = True
+numfig_format = {'figure': 'Fig. %s', 'table': 'Table %s', 'code-block': 'Listing %s'}

--- a/source/intro/install-impexp.rst
+++ b/source/intro/install-impexp.rst
@@ -51,7 +51,7 @@ use the starter script in the *bin* subfolder.
 The installation directory contains the following subfolders:
 
 .. table:: Contents of the installation directory
-   :widths: auto
+   :align: left
 
    ================= ============ ==============================================================================================
    **Folder**        **Optional** **Explanation**

--- a/source/intro/install-impexp.rst
+++ b/source/intro/install-impexp.rst
@@ -46,6 +46,8 @@ use the starter script in the *bin* subfolder.
 
 The installation directory contains the following subfolders:
 
+.. table:: Contents of the installation directory
+
 ================= ============ ==============================================================================================
 **Folder**        **Optional** **Explanation**
 3dcitydb          **x**        **Contains all SQL scripts and stored procedures for operating the 3DCityDB**
@@ -62,8 +64,6 @@ templates                      Contains HTML templates for information balloons 
 uninstaller                    Contains a JAR executable that uninstalls the Importer/Exporter
 README.txt                     A brief information about the application
 ================= ============ ==============================================================================================
-
-Table 18: Contents of the installation directory.
 
 .. |image57| figure:: ../media/image68.png
    :width: 4.58268in

--- a/source/intro/install-impexp.rst
+++ b/source/intro/install-impexp.rst
@@ -51,7 +51,6 @@ use the starter script in the *bin* subfolder.
 The installation directory contains the following subfolders:
 
 .. table:: Contents of the installation directory
-   :align: left
 
    ================= ============ ==============================================================================================
    **Folder**        **Optional** **Explanation**

--- a/source/intro/install-impexp.rst
+++ b/source/intro/install-impexp.rst
@@ -51,20 +51,21 @@ use the starter script in the *bin* subfolder.
 The installation directory contains the following subfolders:
 
 .. table:: Contents of the installation directory
+   :widths: auto
 
-    ================= ============ ==============================================================================================
-    **Folder**        **Optional** **Explanation**
-    3dcitydb          **x**        **Contains all SQL scripts and stored procedures for operating the 3DCityDB**
-    3d-web-map-client **x**        **Contains a ZIP archive containing all files required to install the 3D Web Map Client on a web server**
-    ade-extensions                 **Contains extension packages to support CityGML ADEs.** ADE extensions only must be copied to this directory to make them available in the program.
-    bin                            **Platform-specific starter scripts to launch the Importer/Exporter. For instance, under Windows, double-click on 3DCityDB-Importer-Exporter.bat to run the program**
-    contribs                       **Third-party tools required by the Importer/Exporter (e.g. collada2gltf converter binaries)**
-    lib                            Contains all libraries required by the Importer/Exporter
-    licence                        Contains the license documents for Importer/Exporter
-    manual            x            Contains the documentation for the **3DCityDB and the tools**
-    plugins                        Contains plugins of the Importer/Exporter. Plugins only have to be copied to this directory to make them available in the program.
-    samples           x            Contains CityGML and KML/COLLADA test datasets
-    templates                      Contains HTML templates for information balloons for KML/COLLADA exports, a selection of coordinate reference systems in the form of XML documents, and example XSLT stylesheets to be used in imports and exports.
-    uninstaller                    Contains a JAR executable that uninstalls the Importer/Exporter
-    README.txt                     A brief information about the application
-    ================= ============ ==============================================================================================
+   ================= ============ ==============================================================================================
+   **Folder**        **Optional** **Explanation**
+   3dcitydb          **x**        **Contains all SQL scripts and stored procedures for operating the 3DCityDB**
+   3d-web-map-client **x**        **Contains a ZIP archive containing all files required to install the 3D Web Map Client on a web server**
+   ade-extensions                 **Contains extension packages to support CityGML ADEs.** ADE extensions only must be copied to this directory to make them available in the program.
+   bin                            **Platform-specific starter scripts to launch the Importer/Exporter. For instance, under Windows, double-click on 3DCityDB-Importer-Exporter.bat to run the program**
+   contribs                       **Third-party tools required by the Importer/Exporter (e.g. collada2gltf converter binaries)**
+   lib                            Contains all libraries required by the Importer/Exporter
+   licence                        Contains the license documents for Importer/Exporter
+   manual            x            Contains the documentation for the **3DCityDB and the tools**
+   plugins                        Contains plugins of the Importer/Exporter. Plugins only have to be copied to this directory to make them available in the program.
+   samples           x            Contains CityGML and KML/COLLADA test datasets
+   templates                      Contains HTML templates for information balloons for KML/COLLADA exports, a selection of coordinate reference systems in the form of XML documents, and example XSLT stylesheets to be used in imports and exports.
+   uninstaller                    Contains a JAR executable that uninstalls the Importer/Exporter
+   README.txt                     A brief information about the application
+   ================= ============ ==============================================================================================

--- a/source/intro/install-impexp.rst
+++ b/source/intro/install-impexp.rst
@@ -10,7 +10,11 @@ simply double-click on the *3DCityDB-Importer-Exporter-4.1.0-Setup.jar*
 file. After accepting the license agreement and specifying an installation
 directory, you can choose the software packages to be installed.
 
-|image57|
+.. figure:: ../media/image68.png
+   :width: 4.58268in
+   :height: 3.39205in
+
+   Installation wizard of Import/Export tool (Step 5).
 
 It is recommended to at least select the packages ‘\ *3D City Database*\ ’
 and ‘\ *Documentation’*. The ‘\ *3D City Database*\ ’ package contains all
@@ -48,25 +52,19 @@ The installation directory contains the following subfolders:
 
 .. table:: Contents of the installation directory
 
-================= ============ ==============================================================================================
-**Folder**        **Optional** **Explanation**
-3dcitydb          **x**        **Contains all SQL scripts and stored procedures for operating the 3DCityDB**
-3d-web-map-client **x**        **Contains a ZIP archive containing all files required to install the 3D Web Map Client on a web server**
-ade-extensions                 **Contains extension packages to support CityGML ADEs.** ADE extensions only must be copied to this directory to make them available in the program.
-bin                            **Platform-specific starter scripts to launch the Importer/Exporter. For instance, under Windows, double-click on 3DCityDB-Importer-Exporter.bat to run the program**
-contribs                       **Third-party tools required by the Importer/Exporter (e.g. collada2gltf converter binaries)**
-lib                            Contains all libraries required by the Importer/Exporter
-licence                        Contains the license documents for Importer/Exporter
-manual            x            Contains the documentation for the **3DCityDB and the tools**
-plugins                        Contains plugins of the Importer/Exporter. Plugins only have to be copied to this directory to make them available in the program.
-samples           x            Contains CityGML and KML/COLLADA test datasets
-templates                      Contains HTML templates for information balloons for KML/COLLADA exports, a selection of coordinate reference systems in the form of XML documents, and example XSLT stylesheets to be used in imports and exports.
-uninstaller                    Contains a JAR executable that uninstalls the Importer/Exporter
-README.txt                     A brief information about the application
-================= ============ ==============================================================================================
-
-.. |image57| figure:: ../media/image68.png
-   :width: 4.58268in
-   :height: 3.39205in
-
-   Installation wizard of Import/Export tool (Step 5).
+    ================= ============ ==============================================================================================
+    **Folder**        **Optional** **Explanation**
+    3dcitydb          **x**        **Contains all SQL scripts and stored procedures for operating the 3DCityDB**
+    3d-web-map-client **x**        **Contains a ZIP archive containing all files required to install the 3D Web Map Client on a web server**
+    ade-extensions                 **Contains extension packages to support CityGML ADEs.** ADE extensions only must be copied to this directory to make them available in the program.
+    bin                            **Platform-specific starter scripts to launch the Importer/Exporter. For instance, under Windows, double-click on 3DCityDB-Importer-Exporter.bat to run the program**
+    contribs                       **Third-party tools required by the Importer/Exporter (e.g. collada2gltf converter binaries)**
+    lib                            Contains all libraries required by the Importer/Exporter
+    licence                        Contains the license documents for Importer/Exporter
+    manual            x            Contains the documentation for the **3DCityDB and the tools**
+    plugins                        Contains plugins of the Importer/Exporter. Plugins only have to be copied to this directory to make them available in the program.
+    samples           x            Contains CityGML and KML/COLLADA test datasets
+    templates                      Contains HTML templates for information balloons for KML/COLLADA exports, a selection of coordinate reference systems in the form of XML documents, and example XSLT stylesheets to be used in imports and exports.
+    uninstaller                    Contains a JAR executable that uninstalls the Importer/Exporter
+    README.txt                     A brief information about the application
+    ================= ============ ==============================================================================================


### PR DESCRIPTION
Fixes conf.py. Setting `numfig = True` is enough to have auto-numbering for figures, tables and code blocks.
Tried on installation chapter.
Unfortunately, we have to move image reference inline. But maybe thats even better for latter editing.