### PR TITLE
Build, deploy github-pages

### DIFF
--- a/.github/workflows/build-deploy-github-pages.yml
+++ b/.github/workflows/build-deploy-github-pages.yml
@@ -1,0 +1,25 @@
+name: build-deploy-github-pages
+
+on:
+  push:
+    branches:
+    - master
+
+  pull_request:
+
+jobs:
+  build-deploy-gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Checkout repo
+      uses: actions/checkout@v2.3.4
+    -
+      name: Sphinx build - html
+      run: docker run --rm -v $PWD:/docs bwibo/sphinx-rtd make html
+    -
+      name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@4.0.0
+      with:
+        branch: gh-pages
+        folder: build/html

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = python3 -msphinx
+# SPHINXBUILD   = sphinx-build    # original setting, above is for local build with python3
 PAPER         =
 BUILDDIR      = build
 


### PR DESCRIPTION
This PR adds a Github Action to build the ReadTheDocs HTML page and deploy it to github-pages.
This allows us to preview the latest content of pull requests and commits to master and discuss it based
on a webpage (we can share links to the deployments) that look's like the content on ReadTheDocs.org.