### PR TITLE
drop minor versions and use badges instead

### DIFF
--- a/source/3dcitydb/docker.rst
+++ b/source/3dcitydb/docker.rst
@@ -92,10 +92,9 @@ versions.
     - |psql-deb-size-v4.1.0|
     - |psql-alp-size-v4.1.0|
     - |ora-size-edge|
-  * - 4.2.0
-    - |psql-deb-size-v4.2.0|
-    - |psql-alp-size-v4.2.0|
-    - |ora-size-edge|
+
+.. note:: Minor releases are not listed in this table, please find them on
+  |version-badge-dockerhub| or |version-badge-github|.
 
 The **edge** images are automatically built and published on every push to the
 *master* branch of the `3DCityDB Github repository <https://github.com/3dcitydb/
@@ -347,7 +346,6 @@ and running `docker build <https://docs.docker.com/engine/reference/commandline
         --build-arg BASEIMAGE_TAG=14-3.2 \
       .
 
-
 .. _citydb_docker_oracle_build:
 
 Oracle
@@ -577,6 +575,16 @@ lists the tables of the DB running in the container using ``psql``.
 
 .. Images ---------------------------------------------------------------------
 
+.. version badges
+
+.. |version-badge-github| image:: https://img.shields.io/github/v/release/3dcitydb/3dcitydb?label=Github&logo=github
+  :target: https://github.com/3dcitydb/3dcitydb/releases
+
+.. |version-badge-dockerhub| image:: https://img.shields.io/docker/v/3dcitydb/3dcitydb-pg?label=Docker%20Hub&logo=docker&logoColor=white&sort=semver
+  :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg/tags
+
+.. Oracle license
+
 .. |oracle-license| image:: ../media/citydb_oracle_license.jpg
 
 .. edge
@@ -627,18 +635,5 @@ lists the tables of the DB running in the container using ``psql``.
 
 .. |psql-alp-size-v4.1.0| image:: https://img.shields.io/docker/image-size/
   3dcitydb/3dcitydb-pg/13-3.1-4.1.0-alpine?label=image%20size&logo=Docker&logoColor=white&
-  style=flat-square
-  :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg
-
-.. 4.2.0
-
-.. |psql-deb-size-v4.2.0| image::
-  https://img.shields.io/docker/image-size/
-  3dcitydb/3dcitydb-pg/14-3.1-4.2.0?label=image%20size&logo=Docker&logoColor=white&style=flat-square
-  :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg
-
-.. |psql-alp-size-v4.2.0| image::
-  https://img.shields.io/docker/image-size/
-  3dcitydb/3dcitydb-pg/14-3.1-4.2.0-alpine?label=image%20size&logo=Docker&logoColor=white&
   style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg

--- a/source/3dcitydb/docker.rst
+++ b/source/3dcitydb/docker.rst
@@ -88,13 +88,15 @@ versions.
     - |psql-deb-size-latest|
     - |psql-alp-size-latest|
     - |ora-size-edge|
-  * - 4.1.0
-    - |psql-deb-size-v4.1.0|
-    - |psql-alp-size-v4.1.0|
+  * - 4.0.0
+    - |psql-deb-size-v4.0.0|
+    - |psql-alp-size-v4.0.0|
     - |ora-size-edge|
 
-.. note:: Minor releases are not listed in this table, please find them on
-  |version-badge-dockerhub| or |version-badge-github|.
+.. note::
+  | Minor releases are not listed in this table.
+  | The latest 3DCityDB version is: |version-badge-github|
+  | The latest image version on DockerHub is: |version-badge-dockerhub|
 
 The **edge** images are automatically built and published on every push to the
 *master* branch of the `3DCityDB Github repository <https://github.com/3dcitydb/
@@ -626,14 +628,13 @@ lists the tables of the DB running in the container using ``psql``.
   style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg/tags?page=1&ordering=last_updated
 
+.. 4.0.0
 
-.. 4.1.0
-
-.. |psql-deb-size-v4.1.0| image:: https://img.shields.io/docker/image-size/
-  3dcitydb/3dcitydb-pg/13-3.1-4.1.0?label=image%20size&logo=Docker&logoColor=white&style=flat-square
+.. |psql-deb-size-v4.0.0| image:: https://img.shields.io/docker/image-size/
+  3dcitydb/3dcitydb-pg/14-3.2-4.0.0?label=image%20size&logo=Docker&logoColor=white&style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg
 
-.. |psql-alp-size-v4.1.0| image:: https://img.shields.io/docker/image-size/
-  3dcitydb/3dcitydb-pg/13-3.1-4.1.0-alpine?label=image%20size&logo=Docker&logoColor=white&
+.. |psql-alp-size-v4.0.0| image:: https://img.shields.io/docker/image-size/
+  3dcitydb/3dcitydb-pg/14-3.2-4.0.0-alpine?label=image%20size&logo=Docker&logoColor=white&
   style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg

--- a/source/impexp/docker.rst
+++ b/source/impexp/docker.rst
@@ -55,8 +55,10 @@ an overview on the images available.
     - |deb-size-v5.0.0|
     - |alp-size-v5.0.0|
 
-.. note:: Minor releases are not listed in this table, please find them on
-  |version-badge-dockerhub| or |version-badge-github|.
+.. note::
+  | Minor releases are not listed in this table.
+  | The latest 3DCityDB Importer/Exporter version is: |version-badge-github|
+  | The latest image version on DockerHub is: |version-badge-dockerhub|
 
 The **edge** images are automatically built and published on every push to the
 *master* branch of the `3DCityDB Importer/Exporter Github repository <https://

--- a/source/impexp/docker.rst
+++ b/source/impexp/docker.rst
@@ -35,7 +35,7 @@ The images are going to use the latest LTS JRE version available at the time a n
 Importer/Exporter version is released. :numref:`impexp_docker_tbl_images` gives
 an overview on the images available.
 
-.. list-table:: 3DCityDB Importer/Exporter Docker image variants and versions
+.. list-table:: 3DCityDB Importer/Exporter Docker image variants and major versions
   :widths: auto
   :header-rows: 1
   :stub-columns: 1
@@ -51,15 +51,12 @@ an overview on the images available.
   * - latest
     - |deb-size-latest|
     - |alp-size-latest|
-  * - 4.3.0
-    - |deb-size-v4.3.0|
-    - |alp-size-v4.3.0|
   * - 5.0.0
     - |deb-size-v5.0.0|
     - |alp-size-v5.0.0|
-  * - 5.1.0
-    - |deb-size-v5.1.0|
-    - |alp-size-v5.1.0|
+
+.. note:: Minor releases are not listed in this table, please find them on
+  |version-badge-dockerhub| or |version-badge-github|.
 
 The **edge** images are automatically built and published on every push to the
 *master* branch of the `3DCityDB Importer/Exporter Github repository <https://
@@ -68,6 +65,8 @@ using the latest stable version of the base images.
 The **latest** and **release** image versions  are only built
 when a new release is published on Github. The **latest** tag will point to
 the most recent release version.
+
+
 
 The images are available on `3DCityDB DockerHub <https://hub.docker.com/r/
 3dcitydb/>`_ and can be pulled like this:
@@ -87,8 +86,8 @@ Here are some examples for full image tags:
 
   docker pull 3dcitydb/impexp:edge
   docker pull 3dcitydb/impexp:latest-alpine
-  docker pull 3dcitydb/impexp:5.1.0
-  docker pull 3dcitydb/impexp:5.1.0-alpine
+  docker pull 3dcitydb/impexp:5.0.0
+  docker pull 3dcitydb/impexp:5.0.0-alpine
 
 
 *******************************************************************************
@@ -449,6 +448,16 @@ longer needed and can be removed:
 
 .. Images ---------------------------------------------------------------------
 
+
+.. version badges
+.. |version-badge-github| image:: https://img.shields.io/github/v/release/3dcitydb/importer-exporter?label=Github&logo=github
+  :target: https://github.com/3dcitydb/importer-exporter/releases
+
+.. |version-badge-dockerhub| image:: https://img.shields.io/docker/v/3dcitydb/impexp?label=Docker%20Hub&logo=docker&logoColor=white&sort=semver
+  :target: https://hub.docker.com/r/3dcitydb/impexp/tags
+
+.. edge
+
 .. |deb-build-edge| image:: https://img.shields.io/github/workflow/status/
   3dcitydb/importer-exporter/docker-build-edge?
   style=flat-square&logo=Docker&logoColor=white
@@ -467,21 +476,14 @@ longer needed and can be removed:
   3dcitydb/impexp/edge-alpine?label=image%20size&logo=Docker&logoColor=white&style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/impexp/tags?page=1&ordering=last_updated
 
+.. latest
+
 .. |deb-size-latest| image:: https://img.shields.io/docker/image-size/
   3dcitydb/impexp/latest?label=image%20size&logo=Docker&logoColor=white&style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/impexp/tags?page=1&ordering=last_updated
 
 .. |alp-size-latest| image:: https://img.shields.io/docker/image-size/
   3dcitydb/impexp/latest-alpine?label=image%20size&logo=Docker&logoColor=white&style=flat-square
-  :target: https://hub.docker.com/r/3dcitydb/impexp/tags?page=1&ordering=last_updated
-
-.. 4.3.0
-.. |deb-size-v4.3.0| image:: https://img.shields.io/docker/image-size/
-  3dcitydb/impexp/4.3.0?label=image%20size&logo=Docker&logoColor=white&style=flat-square
-  :target: https://hub.docker.com/r/3dcitydb/impexp/tags?page=1&ordering=last_updated
-
-.. |alp-size-v4.3.0| image:: https://img.shields.io/docker/image-size/
-  3dcitydb/impexp/4.3.0-alpine?label=image%20size&logo=Docker&logoColor=white&style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/impexp/tags?page=1&ordering=last_updated
 
 .. 5.0.0
@@ -491,13 +493,4 @@ longer needed and can be removed:
 
 .. |alp-size-v5.0.0| image:: https://img.shields.io/docker/image-size/
   3dcitydb/impexp/5.0.0-alpine?label=image%20size&logo=Docker&logoColor=white&style=flat-square
-  :target: https://hub.docker.com/r/3dcitydb/impexp/tags?page=1&ordering=last_updated
-
-.. 5.1.0
-.. |deb-size-v5.1.0| image:: https://img.shields.io/docker/image-size/
-  3dcitydb/impexp/5.1.0?label=image%20size&logo=Docker&logoColor=white&style=flat-square
-  :target: https://hub.docker.com/r/3dcitydb/impexp/tags?page=1&ordering=last_updated
-
-.. |alp-size-v5.1.0| image:: https://img.shields.io/docker/image-size/
-  3dcitydb/impexp/5.1.0-alpine?label=image%20size&logo=Docker&logoColor=white&style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/impexp/tags?page=1&ordering=last_updated

--- a/source/wfs/docker.rst
+++ b/source/wfs/docker.rst
@@ -34,7 +34,7 @@ the images.
     3dcitydb/wfs[:TAG]
 
 When running containers with default settings, the
-:ref:`WFS <_wfs_basic_functionality_chapter>` will listen at following URL.
+:ref:`WFS <wfs_basic_functionality_chapter>` will listen at following URL.
 Note that the web root is used as context path in this case.
 
 .. code-block:: bash
@@ -85,6 +85,9 @@ the most recent release version.
   * - 5.0.0
     - |deb-size-v5.0.0|
     - |alp-size-v5.0.0|
+
+.. note:: Minor releases are not listed in this table, please find them on
+  |version-badge-dockerhub| or |version-badge-github|.
 
 The images are available on `3DCityDB DockerHub <https://hub.docker.com/r/
 3dcitydb/>`_ and can be pulled like this:
@@ -444,6 +447,16 @@ When the services and network are no longer required, they can be removed:
 
 .. Images ---------------------------------------------------------------------
 
+.. version badges
+
+.. |version-badge-github| image:: https://img.shields.io/github/v/release/3dcitydb/web-feature-service?label=Github&logo=github
+  :target: https://github.com/3dcitydb/web-feature-service/releases
+
+.. |version-badge-dockerhub| image:: https://img.shields.io/docker/v/3dcitydb/wfs?label=Docker%20Hub&logo=docker&logoColor=white&sort=semver
+  :target: https://hub.docker.com/r/3dcitydb/wfs/tags
+
+.. edge
+
 .. |deb-build-edge| image:: https://img.shields.io/github/workflow/status/
   3dcitydb/web-feature-service/docker-build-edge?
   style=flat-square&logo=Docker&logoColor=white
@@ -461,6 +474,8 @@ When the services and network are no longer required, they can be removed:
 .. |alp-size-edge| image:: https://img.shields.io/docker/image-size/
   3dcitydb/wfs/edge-alpine?label=image%20size&logo=Docker&logoColor=white&style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/wfs/tags?page=1&ordering=last_updated
+
+.. latest
 
 .. |deb-size-latest| image:: https://img.shields.io/docker/image-size/
   3dcitydb/wfs/latest?label=image%20size&logo=Docker&logoColor=white&style=flat-square

--- a/source/wfs/docker.rst
+++ b/source/wfs/docker.rst
@@ -86,8 +86,10 @@ the most recent release version.
     - |deb-size-v5.0.0|
     - |alp-size-v5.0.0|
 
-.. note:: Minor releases are not listed in this table, please find them on
-  |version-badge-dockerhub| or |version-badge-github|.
+.. note::
+  | Minor releases are not listed in this table.
+  | The latest 3DCityDB WFS version is: |version-badge-github|
+  | The latest image version on DockerHub is: |version-badge-dockerhub|
 
 The images are available on `3DCityDB DockerHub <https://hub.docker.com/r/
 3dcitydb/>`_ and can be pulled like this:


### PR DESCRIPTION
The version tables on the Docker pages needed to be maintained for each release. This PR drops minor versions from the table and uses badges that link to Github and DockerHub instead.
In the future, the tables need manual updating only for major releases.

![grafik](https://user-images.githubusercontent.com/7643434/162922522-b198b684-3b13-4657-883a-e23ac8344c84.png)
