### PR TITLE
Fix docker image build status badges

### DIFF
--- a/source/3dcitydb/docker.rst
+++ b/source/3dcitydb/docker.rst
@@ -612,8 +612,8 @@ lists the tables of the DB running in the container using ``psql``.
 
 .. edge
 
-.. |psql-deb-build-edge| image:: https://img.shields.io/github/workflow/status/
-  3dcitydb/3dcitydb/psql-docker-build-push-edge?label=Debian&
+.. |psql-deb-build-edge| image:: https://img.shields.io/github/actions/workflow/status/
+  3dcitydb/3dcitydb/psql-docker-build-push-edge.yml?label=Debian&
   style=flat-square&logo=Docker&logoColor=white
   :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg/tags?page=1&ordering=last_updated
 
@@ -621,8 +621,8 @@ lists the tables of the DB running in the container using ``psql``.
   3dcitydb/3dcitydb-pg/edge?label=image%20size&logo=Docker&logoColor=white&style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg/tags?page=1&ordering=last_updated
 
-.. |psql-alp-build-edge| image:: https://img.shields.io/github/workflow/status/
-  3dcitydb/3dcitydb/psql-docker-build-push-edge?label=Alpine&
+.. |psql-alp-build-edge| image:: https://img.shields.io/github/actions/workflow/status/
+  3dcitydb/3dcitydb/psql-docker-build-push-edge.yml?label=Alpine&
   style=flat-square&logo=Docker&logoColor=white
   :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg/tags?page=1&ordering=last_updated
 
@@ -631,8 +631,8 @@ lists the tables of the DB running in the container using ``psql``.
   style=flat-square
   :target: https://hub.docker.com/r/3dcitydb/3dcitydb-pg/tags?page=1&ordering=last_updated
 
-.. |ora-build-edge| image:: https://img.shields.io/github/workflow/status/
-  3dcitydb/3dcitydb/oracle-docker-build-edge?label=Oracle%20Linux&
+.. |ora-build-edge| image:: https://img.shields.io/github/actions/workflow/status/
+  3dcitydb/3dcitydb/oracle-docker-build-edge.yml?label=Oracle%20Linux&
   style=flat-square&logo=Docker&logoColor=white
 
 .. |ora-size-edge| image:: https://img.shields.io/static/v1?label=image%20size&message=

--- a/source/impexp/docker.rst
+++ b/source/impexp/docker.rst
@@ -89,7 +89,6 @@ Here are some examples for full image tags:
   docker pull 3dcitydb/impexp:5.0.0
   docker pull 3dcitydb/impexp:5.0.0-alpine
 
-
 *******************************************************************************
 Usage and configuration
 *******************************************************************************
@@ -457,13 +456,13 @@ longer needed and can be removed:
 
 .. edge
 
-.. |deb-build-edge| image:: https://img.shields.io/github/workflow/status/
-  3dcitydb/importer-exporter/docker-build-edge?
+.. |deb-build-edge| image:: https://img.shields.io/github/actions/workflow/status/
+  3dcitydb/importer-exporter/docker-build-edge.yml?
   style=flat-square&logo=Docker&logoColor=white
   :target: https://hub.docker.com/r/3dcitydb/impexp/tags?page=1&ordering=last_updated
 
-.. |alp-build-edge| image:: https://img.shields.io/github/workflow/status/
-  3dcitydb/importer-exporter/docker-build-edge-alpine?
+.. |alp-build-edge| image:: https://img.shields.io/github/actions/workflow/status/
+  3dcitydb/importer-exporter/docker-build-edge-alpine.yml?
    style=flat-square&logo=Docker&logoColor=white
   :target: https://hub.docker.com/r/3dcitydb/impexp/tags?page=1&ordering=last_updated
 

--- a/source/wfs/docker.rst
+++ b/source/wfs/docker.rst
@@ -463,13 +463,13 @@ When the services and network are no longer required, they can be removed:
 
 .. edge
 
-.. |deb-build-edge| image:: https://img.shields.io/github/workflow/status/
-  3dcitydb/web-feature-service/docker-build-edge?
+.. |deb-build-edge| image:: https://img.shields.io/github/actions/workflow/status/
+  3dcitydb/web-feature-service/docker-build-edge.yml?
   style=flat-square&logo=Docker&logoColor=white
   :target: https://hub.docker.com/r/3dcitydb/wfs/tags?page=1&ordering=last_updated
 
-.. |alp-build-edge| image:: https://img.shields.io/github/workflow/status/
-  3dcitydb/web-feature-service/docker-build-edge-alpine?
+.. |alp-build-edge| image:: https://img.shields.io/github/actions/workflow/status/
+  3dcitydb/web-feature-service/docker-build-edge-alpine.yml?
    style=flat-square&logo=Docker&logoColor=white
   :target: https://hub.docker.com/r/3dcitydb/wfs/tags?page=1&ordering=last_updated
 


### PR DESCRIPTION
This fixes https://github.com/badges/shields/issues/8671 for 3dcitydb, impexp and wfs docker image docs.